### PR TITLE
v0.2.2: Update to AWS SDK v3

### DIFF
--- a/cfn-events.gemspec
+++ b/cfn-events.gemspec
@@ -34,6 +34,6 @@ lib/cfn-events/version.rb
 
   s.require_paths = ["lib"]
 
-  s.add_dependency 'aws-sdk', "~> 2.0"
+  s.add_dependency 'aws-sdk-cloudformation', "~> 1.0"
   s.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/lib/cfn-events/version.rb
+++ b/lib/cfn-events/version.rb
@@ -1,3 +1,3 @@
 module CfnEvents
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
AWS SDK v3 is API compatible with v2.  The only change is that the SDK is now modular and made up of multiple gems.